### PR TITLE
Add page names to Game, Box

### DIFF
--- a/src/routes/(app)/box/+page.svelte
+++ b/src/routes/(app)/box/+page.svelte
@@ -225,6 +225,10 @@
   }
 </script>
 
+<svelte:head>
+  <title>Nuzlocke Tracker | Box</title>
+</svelte:head>
+
 {#if loading}
   <Loader />
 {:else}

--- a/src/routes/(app)/game/+page.svelte
+++ b/src/routes/(app)/game/+page.svelte
@@ -132,6 +132,10 @@
   }
 </script>
 
+<svelte:head>
+  <title>Nuzlocke Tracker | Game</title>
+</svelte:head>
+
 <SupportBanner />
 
 {#await setup()}


### PR DESCRIPTION
When moving from graveyard page, page name will now change (formerly did not)