### PR TITLE
Fix/correct move and abilities

### DIFF
--- a/src/lib/data/league.json
+++ b/src/lib/data/league.json
@@ -104577,7 +104577,7 @@
           "name": "shiinotic",
           "level": "51",
           "moves": [
-            "moonlight",
+            "moonblast",
             "giga-drain",
             "spore"
           ],

--- a/src/lib/data/league.json
+++ b/src/lib/data/league.json
@@ -104735,9 +104735,9 @@
             "discharge",
             "tri-attack"
           ],
-          "ability": "sturdy",
+          "ability": "magnet-pull",
           "abilities": [
-            "sturdy"
+            "magnet-pull"
           ]
         },
         {
@@ -104748,9 +104748,9 @@
             "thunder-punch",
             "steamroller"
           ],
-          "ability": "sturdy",
+          "ability": "magnet-pull",
           "abilities": [
-            "sturdy"
+            "magnet-pull"
           ],
           "held": "electrium-z--held",
           "sprite": "golem-alola"


### PR DESCRIPTION
Small corrections
Captain Marlow's Shiinotic should have Moonblast and not Moonlight.
Source: My own Nuzlocke in which my Bewear got wiped to Moonblast lmao.
Actual source: 
https://gamefaqs.gamespot.com/3ds/210931-pokemon-ultra-moon/faqs/75389/captain-mallow

With Sophocles I noticed that the Magnezone died to one hit which made me look up if it's supposed to have Sturdy and it seems like it doesn't:
https://gamefaqs.gamespot.com/3ds/210931-pokemon-ultra-moon/faqs/75389/captain-sophocles

While reading it I noticed the same for Alolan Golem